### PR TITLE
add pages for students including olympiad practice/mentoring program

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -57,33 +57,46 @@
       fr: "/activities_fr/"
 
 - title:
-    en: "Public Lectures"
-    fr: "Conférences publiques"
+    en: "For students"
+    fr: "Pour les élèves"
   url:
-    en: "/lectures/"
-    fr: "/lectures_fr/"
+    en: "/students/"
+    fr: "/students_fr/"
   side: left
   dropdown:
-  - title:
-      en: "Physics Matters series"
-      fr: "La physique dans Tous ses États"
-    url:
-      en: "/lectures/"
-      fr: "/lectures_fr/"
-  - title:
-      en: "Anna I. McPherson series"
-      fr: "Série de colloques Anna I. McPherson"
-    url:
-      en: "/mcpherson/"
-      fr: "/mcpherson_fr/"
+    - title:
+        en: "Visit us at McGill"
+        fr: "Rendez-nous visite"
+      url:
+        en: "/students/"
+        fr: "/students_fr/"
+    - title:
+        en: McGill Physics Olympiad Program
+        fr: McGill Physics Olympiad Program
+      url:
+        en: "/mpop/"
+        fr: "/mpop_fr/"
 
 - title:
-    en: Events
-    fr: Évenements
+    en: "Public Events"
+    fr: "Événements publics"
   url:
     en: "/events/"
     fr: "/events_fr/"
   side: left
+  dropdown:
+  - title:
+      en: "Physics Matters lecture series"
+      fr: "Série de colloques 'La physique dans Tous ses États'"
+    url:
+      en: "/lectures/"
+      fr: "/lectures_fr/"
+  - title:
+      en: "Anna I. McPherson lecture series"
+      fr: "Série de colloques Anna I. McPherson"
+    url:
+      en: "/mcpherson/"
+      fr: "/mcpherson_fr/"
 
 - title:
     en: Partners

--- a/_includes/_sidebar.html
+++ b/_includes/_sidebar.html
@@ -1,14 +1,15 @@
 <aside>
 	<div class="panel radius">
+		{% comment %} French version {% endcomment %}
 		{% if lang == 'fr' %}
-			<h3>Joignez-vous à nous...</h3>
-			<p>Need translation in _includes/_sidebar.html</p>
+			<h3>Découvrez la physique de pointe !</h3>
+			<p>Le groupe de vulgarisation du département de Physique de l’université McGill vous présente les colloques 'La Physique Dans Tous Ses Etats' ! <b>Need to finish the translation (in the file _includes/_sidebar.html)</b> These lectures are aimed at anyone who wants to learn more about current physics topics - no science background is necessary. Whether you are a long-time science enthusiast, or have developed a new interest in physics, we invite you to join us to learn about cutting edge science from the experts doing the research!</p>
 
-		{% comment %}English version (default){% endcomment %}
+		{% comment %} English version (default) {% endcomment %}
 		{% else %}
 			<h3>Join us for cutting edge science!</h3>
 			<p>
-			The Physics Matters (“La physique dans toutes ses états”) outreach group in the McGill Department of Physics presents the Physics Matters public lecture series!  These lectures are aimed at anyone who wants to learn more about current physics topics - no science background is necessary. Whether you are a long-time science enthusiast, or have developed a new interest in physics, we invite you to join us to learn about cutting edge science from the experts doing the research!
+			The Physics Matters outreach group in the McGill Department of Physics presents the Physics Matters public lecture series!  These lectures are aimed at anyone who wants to learn more about current physics topics - no science background is necessary. Whether you are a long-time science enthusiast, or have developed a new interest in physics, we invite you to join us to learn about cutting edge science from the experts doing the research!
 			</p>
 			<p>
 			The lectures are held at 7pm, usually on the first Thursday of each month. We will explore nanotechnology, high energy particle physics, nonlinear physics, biophysics, and more!

--- a/pages/mpop.md
+++ b/pages/mpop.md
@@ -1,0 +1,10 @@
+---
+layout: page
+title: "McGill Physics Olympiad Program"
+lang: en
+header: no
+permalink: /mpop/
+---
+*This page is under construction. Check back soon for more details.*
+
+The McGill Physics Olympiad Program (MPOP) is a program to provide mentorship and practice sessions to students interested in participating in competitive science olympiads.

--- a/pages/mpop_fr.md
+++ b/pages/mpop_fr.md
@@ -1,0 +1,9 @@
+---
+layout: page
+title: "McGill Physics Olympiad Program"
+lang: fr
+header: no
+permalink: /mpop_fr/
+---
+
+*Cette page est en contruction et elle n'est pas disponsible en français pour le moment. Le traduction va ếtre disponsible bientôt.*

--- a/pages/partners.md
+++ b/pages/partners.md
@@ -12,6 +12,8 @@ links:
   - url: https://sites.google.com/site/womeninphysicsmcgill/home
     logo: partnerlogo_wip.png
     text: Women in Physics at McGill University
+  - url: http://www.physics.mcgill.ca/museum/rutherford_museum.htm
+    text: The Rutherford Museum
 permalink: "/partners/"
 ---
 

--- a/pages/partners_fr.md
+++ b/pages/partners_fr.md
@@ -12,6 +12,8 @@ links:
   - url: https://sites.google.com/site/womeninphysicsmcgill/home
     logo: partnerlogo_wip.png
     text: Women in Physics at McGill University
+  - url: http://www.physics.mcgill.ca/museum/rutherford_museum.htm
+    text: Le musée Rutherford
 permalink: "/partners_fr/"
 ---
 

--- a/pages/students.md
+++ b/pages/students.md
@@ -1,0 +1,19 @@
+---
+layout: frontpage
+title: "For Students"
+lang: en
+header:
+   image_fullwidth: "openhouse_outside.jpg"
+permalink: /students/
+---
+## Open House
+Interested in pursuing an undergraduate physics degree? Wondering what kind of research happens in the physics department at McGill? Each year we host an open house for students interested in seeing what our department is all about. Watch the [events page]({{ site.baseurl }}{{ events }}) for more details.
+
+## Physics Hackathon
+The [McGill Physics hackathon](http://www.physics.mcgill.ca/hackathon2017/), started in 2016, is a hackathon devoted to solving and visualizing physics problems. Participant teams will be challenged to use scientific computing tools and/or microelectronic gadgets to demonstrate a concept, phenomenon or application involving the physical sciences.
+
+## McGill Physics Olympiad Program
+Are you a high school or CEGEP student interested in competitive physics olympiads? Our [McGill Physics Olympiad Program]({{ site.baseurl }}{{ mpop }}) (MPOP) offers mentorship and practice sessions led by undergraduate physics students experienced in these competitions.
+
+## Visit us at McGill
+We are able to host school or extracurricular groups at our department at McGill University. We have a variety of activities for all ages, offered in French or English. Typical visits vary in length, and may involve museum tours, lab tours, short demos, or hands-on activities. Have your teacher or group leader [contact us]("mailto:{{ site.email }}") for information or to request a visit. Visit date and language are subject to volunteer availability.

--- a/pages/students_fr.md
+++ b/pages/students_fr.md
@@ -1,0 +1,22 @@
+---
+layout: frontpage
+title: "For Students"
+lang: en
+header:
+   image_fullwidth: "openhouse_outside.jpg"
+permalink: /students/
+---
+*Traduction en course*
+
+## Open House
+Interested in pursuing an undergraduate physics degree? Wondering what kind of research happens in the physics department at McGill? Each year we host an open house for students interested in seeing what our department is all about. Watch the [events page]({{ site.baseurl }}{{ events }}) for more details.
+
+## Physics Hackathon
+The [McGill Physics hackathon](http://www.physics.mcgill.ca/hackathon2017/), started in 2016, is a hackathon devoted to solving and visualizing physics problems. Participant teams will be challenged to use scientific computing tools and/or microelectronic gadgets to demonstrate a concept, phenomenon or application involving the physical sciences.
+
+## McGill Physics Olympiad Program
+Are you a high school or CEGEP student interested in competitive physics olympiads? Our [McGill Physics Olympiad Program]({{ site.baseurl }}{{ mpop }}) (MPOP) offers mentorship and practice sessions led by undergraduate physics students experienced in these competitions.
+
+## Visit us at McGill
+Nous pouvons accueillir de groupes scolaires ou extra-scolaires à McGill. Nous disposons d'un certains nombre d'activités que nous pouvons animer en français ou en anglais pour des jeunes de tout âge. La visite peut aussi inclure un tour dans le musée Rutherford, le tour de certain laboratoires de recherche ainsi que diverses activités de démosntration.
+Pour toute visite, votre profeseur ou chef de groupe doit [nous contacter]("mailto:{{ site.email }}") pour arranger une date.

--- a/pages/students_fr.md
+++ b/pages/students_fr.md
@@ -4,7 +4,7 @@ title: "For Students"
 lang: en
 header:
    image_fullwidth: "openhouse_outside.jpg"
-permalink: /students/
+permalink: /students_fr/
 ---
 *Traduction en course*
 


### PR DESCRIPTION
Also changed around the navigation menu: all events are now under one heading (public lectures do not have their own link in the main menu, but are in the events drop-down menu) and there is a new main-level link to a For Students page which has information on the hackathon, MPOP, and open house.